### PR TITLE
Make VS Code prompt for target device on every run

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "monkeyc",
+      "request": "launch",
+      "name": "Run App",
+      "stopAtLaunch": false,
+      "device": "${command:GetTargetDevice}"
+    },
+    {
+      "type": "monkeyc",
+      "request": "launch",
+      "name": "Run Tests",
+      "runTests": true,
+      "device": "${command:GetTargetDevice}"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is opti
 
 Must be one of the following:
 
+- `build`: Changes that affect the build system or external dependencies
 - `docs`: Documentation change
 - `feat`: A new feature
 - `fix`: A bug fix


### PR DESCRIPTION
* Improves dev experience by adding `.vscode/launch.json` that makes VS Code prompt for a target device whenever the project is being run
* Adds a `build` type for commit messages