### PR TITLE
Singletonize ComplicationsController

### DIFF
--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -1,7 +1,7 @@
 <properties>
   <property id="ShortLabelsSetting" type="boolean">false</property>
-  <property id="ShowSecondsSetting" type="boolean">true</property>
-  <property id="HideUnitsSetting" type="boolean">false</property>
+  <property id="ShowSecondsSetting" type="boolean">false</property>
+  <property id="HideUnitsSetting" type="boolean">true</property>
 
   <property id="UpdateIntervalSetting" type="number">1</property>
   <property id="UpdateIntervalEverySecond" type="number">1</property>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -36,6 +36,7 @@
   <string id="DistanceUnit">m</string>
   <string id="ElevationUnit">m</string>
   <string id="EnergyUnit">kCal</string>
+  <string id="HeartRateUnit">bpm</string>
   <string id="HeightUnit">m</string>
   <string id="PercentUnit">%</string>
   <string id="SpeedUnit">m/s</string>

--- a/source/WatchFaceApp.mc
+++ b/source/WatchFaceApp.mc
@@ -4,8 +4,8 @@ import Toybox.Lang;
 import Toybox.System;
 import Toybox.WatchUi;
 
-var gCallbacks as Types.Controllers.ComplicationsControllerDictionary =
-  ({}) as Types.Controllers.ComplicationsControllerDictionary;
+var gCallbacks as Types.Controllers.ComplicationControllerDictionary =
+  ({}) as Types.Controllers.ComplicationControllerDictionary;
 var gIsLegacyDevice as Boolean = true;
 var gForceRedraw as Boolean = false;
 

--- a/source/components/ProgressBarComponent.mc
+++ b/source/components/ProgressBarComponent.mc
@@ -30,7 +30,6 @@ class ProgressBarComponent extends WatchUi.Drawable {
       mUpdated = Time.now();
     }
 
-    var progress = width * mProgress;
     var totalHeight = !mHideLabel
       ? height +
         Constants.Values.PROGRESS_BAR_LABEL_VERTICAL_OFFSET +
@@ -43,7 +42,7 @@ class ProgressBarComponent extends WatchUi.Drawable {
     dc.fillRectangle(locX - width / 2, locY, width, height);
 
     dc.setColor(Constants.Colors.PRIMARY, Constants.Colors.BACKGROUND);
-    dc.fillRectangle(locX - width / 2, locY, progress, height);
+    dc.fillRectangle(locX - width / 2, locY, width * mProgress, height);
 
     if (!mHideLabel) {
       dc.setColor(Constants.Colors.SECONDARY, Constants.Colors.BACKGROUND);

--- a/source/controllers/ComplicationsController.mc
+++ b/source/controllers/ComplicationsController.mc
@@ -108,7 +108,14 @@ class ComplicationsController extends BaseController {
   }
 
   public function getUnit() as String {
-    return mUnit;
+    switch (mType) {
+      case Complications.COMPLICATION_TYPE_CALORIES:
+        return Application.loadResource(Rez.Strings.EnergyUnit) as String;
+      case Complications.COMPLICATION_TYPE_HEART_RATE:
+        return Application.loadResource(Rez.Strings.HeartRateUnit) as String;
+      default:
+        return mUnit;
+    }
   }
 
   public function getValue() as String or Numeric {

--- a/source/controllers/ComplicationsController.mc
+++ b/source/controllers/ComplicationsController.mc
@@ -5,6 +5,8 @@ import Toybox.Lang;
 import Toybox.System;
 
 class ComplicationsController extends BaseController {
+  hidden static var instances as Types.Controllers.ComplicationDict?;
+
   hidden var mType as Complications.Type;
   hidden var mValue as String or Numeric;
   hidden var mUnit as String;
@@ -14,9 +16,26 @@ class ComplicationsController extends BaseController {
     mType = type;
     mUnit = Application.loadResource(Rez.Strings.UnknownUnit) as String;
     mValue = Application.loadResource(Rez.Strings.UnknownValue) as String;
-    Utils.Complications.registerToComplicationChangeCallback(
-      type,
-      self.method(:onComplicationUpdate)
+    Utils.Complications.registerUpdateCallback(type, self.method(:onComplicationUpdate));
+  }
+
+  static function getInstance(
+    type as Complications.Type
+  ) as Types.Controllers.EverythingController {
+    if (instances == null) {
+      instances = ({}) as Types.Controllers.ComplicationDict;
+    }
+
+    if (!(instances as Types.Controllers.ComplicationDict).hasKey(type)) {
+      (instances as Types.Controllers.ComplicationDict).put(
+        type,
+        new ComplicationsController(type as Complications.Type)
+      );
+    }
+
+    return (
+      (instances as Types.Controllers.ComplicationDict).get(type) as
+      Types.Controllers.EverythingController
     );
   }
 

--- a/source/controllers/LegacyHeartRateController.mc
+++ b/source/controllers/LegacyHeartRateController.mc
@@ -25,6 +25,10 @@ class LegacyHeartRateController extends BaseController {
     return Utils.HeartRate.getHeartRateProgress(Utils.HeartRate.getLegacyHeartRate());
   }
 
+  public function getUnit() as String {
+    return Application.loadResource(Rez.Strings.HeartRateUnit) as String;
+  }
+
   public function getValue() as String or Numeric {
     var heartRate = Utils.HeartRate.getLegacyHeartRate();
 

--- a/source/modules/types/Controllers.mc
+++ b/source/modules/types/Controllers.mc
@@ -16,10 +16,7 @@ module Types {
 
     typedef ComplicationUpdater as (Method(id as Complications.Id) as Void);
 
-    typedef ComplicationsControllerDictionary as Dictionary<
-      Complications.Type,
-      ComplicationUpdater
-    >;
+    typedef ComplicationControllerDictionary as Dictionary<Complications.Type, ComplicationUpdater>;
 
     typedef EverythingController as interface {
       function getAngle() as Numeric;

--- a/source/modules/types/Controllers.mc
+++ b/source/modules/types/Controllers.mc
@@ -18,6 +18,11 @@ module Types {
 
     typedef ComplicationControllerDictionary as Dictionary<Complications.Type, ComplicationUpdater>;
 
+    typedef ComplicationDict as Dictionary<
+      Complications.Type,
+      Types.Controllers.EverythingController
+    >;
+
     typedef EverythingController as interface {
       function getAngle() as Numeric;
       function getIcon() as BitmapResource?;

--- a/source/modules/utils/Complications.mc
+++ b/source/modules/utils/Complications.mc
@@ -15,7 +15,7 @@ module Utils {
       return false;
     }
 
-    function registerToComplicationChangeCallback(
+    function registerUpdateCallback(
       type as Complications.Type,
       callback as Types.Controllers.ComplicationUpdater
     ) as Void {

--- a/source/modules/utils/Controller.mc
+++ b/source/modules/utils/Controller.mc
@@ -13,25 +13,25 @@ module Utils {
         case Types.Controllers.BATTERY:
           return gIsLegacyDevice
             ? new LegacyBatteryController(controller)
-            : new ComplicationsController(Complications.COMPLICATION_TYPE_BATTERY);
+            : ComplicationsController.getInstance(Complications.COMPLICATION_TYPE_BATTERY);
         case Types.Controllers.BLUETOOTH_STATUS:
           return new BluetoothStatusController(controller);
         case Types.Controllers.CALORIES:
           return gIsLegacyDevice
             ? new LegacyCaloriesController(controller)
-            : new ComplicationsController(Complications.COMPLICATION_TYPE_CALORIES);
+            : ComplicationsController.getInstance(Complications.COMPLICATION_TYPE_CALORIES);
         case Types.Controllers.CURRENT_TIME:
           return new CurrentTimeController(controller);
         case Types.Controllers.HEART_RATE:
           return gIsLegacyDevice
             ? new LegacyHeartRateController(controller)
-            : new ComplicationsController(Complications.COMPLICATION_TYPE_HEART_RATE);
+            : ComplicationsController.getInstance(Complications.COMPLICATION_TYPE_HEART_RATE);
         case Types.Controllers.SECONDS:
           return new SecondsController(controller);
         case Types.Controllers.STEPS:
           return gIsLegacyDevice
             ? new LegacyStepsController(controller)
-            : new ComplicationsController(Complications.COMPLICATION_TYPE_STEPS);
+            : ComplicationsController.getInstance(Complications.COMPLICATION_TYPE_STEPS);
         default:
           throw new Exceptions.InvalidControllerIdException(controller);
       }


### PR DESCRIPTION
* Implements a singleton pattern for `source/controllers/ComplicationsController.mc`
  * This allows the controller's data to be accessed by multiple components at the same time
  * This also unifies the functionality between legacy controllers and the single ComplicationsController
* Changes default values of `ShowSecondsSetting` and `HideUnitsSetting`
* Adds missing units for Steps (Complication) and Heart Rate (legacy and Complication)